### PR TITLE
Output 25 up

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,10 @@ Similar to previous instructions, please add the below values to the "_Admin Lab
 
 Once all of the above steps are set up correctly, the plugin should function.
 
+## Updates
+
+### v1.1.0 (6/24/2020)
+Added a new private method to `includes/class-wp-print-helper.php`. The plugin now supports an output of 300 DPI image of a 25-up PDF
+on a 12" x 18" stock. To activate this output, a new flag has been added to the `business_card_proof()` method as an argument. 
+
 Cheers! :beer:

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -208,6 +208,9 @@ class Wp_Print_Preview_Helper
         // write Image to /wp-content/uploads/business_cards
         $this->_writeToUploads( $image, $entry_filename . '.pdf' );
 
+        // create 25 up output on 12 x 18
+        $this->create25Up( $image, $entry_filename );
+
         /** CREATE PNG FILE FOR PREVIEW */
         // Switch format to PNG
         $image->setImageFormat( 'png' );
@@ -215,7 +218,7 @@ class Wp_Print_Preview_Helper
         // Filename for temporary file Preview
         $temp_file = 'business_card_template';
 
-        // write latest file to entry
+        // write latest file to entry for preview
         $image->writeImage( $assets_dir . $temp_file . '.png' );
 
         // return the img filename to shortcode
@@ -345,7 +348,7 @@ class Wp_Print_Preview_Helper
             /**
              * Write the new file to wp-content/uploads via Image Magick
              *
-             * For Ubuntu servrs, please change uploads folder's group ownership
+             * For Ubuntu servers, please change uploads folder's group ownership
              * @see - https://stackoverflow.com/questions/15716428/cannot-save-thumbnail-with-imagick
              */
             $image->writeImage( $bc_dirname . '/' . $filename );
@@ -354,11 +357,30 @@ class Wp_Print_Preview_Helper
     }
 
     /**
-     * @param $image - Image Magick oject (Business Card)
+     * Creates and writes a 25 up Business Card printout on a 12 x 18 stock
+     * @param $image - Image Magick object (Business Card)
      * @param $filename - name of file to be saved as
      */
     public function create25Up( $image, $filename )
     {
+        // new filename for 25-up PDF
+        $new_filename = $filename . '_25_up.pdf';
 
+        // create Stack of Images (i.e. 5x5)
+        $stack = new Imagick();
+
+        // create 25 images in the stack at 300 DPI
+        for ( $i = 0; $i < 25; $i++ )
+        {
+            $stack->addImage( $image );
+            $stack->setImageColorspace( Imagick::COLORSPACE_SRGB );
+            $stack->setImageUnits( Imagick::RESOLUTION_PIXELSPERINCH );
+            $stack->setResolution( 600, 600 );
+            $stack->setImageResolution( 300, 300 );
+        }
+        // Create raw 17.5" x 10" 25 up (before adding padding to the edges for 18" x 12" centering)
+        $montage = $stack->montageImage( new ImagickDraw(), '5x5', '2100x1200', 0, 0);
+
+        $this->_writeToUploads( $montage, $new_filename );
     }
 }

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -2,7 +2,13 @@
 
 class Wp_Print_Preview_Helper
 {
-    public function business_card_proof( $entry )
+    /**
+     * @param $entry - Gravity Forms entry object
+     * @param $create25up - flag to indicate to create 25-up PDF (not required in preview)
+     * @return string
+     * @throws ImagickException
+     */
+    public function business_card_proof( $entry, $create25up )
     {
         // Store entry_id in SESSION
         // i.e. /?add_to_cart=39 will have access to this entry_id upon "Add Order"
@@ -208,8 +214,10 @@ class Wp_Print_Preview_Helper
         // write Image to /wp-content/uploads/business_cards
         $this->_writeToUploads( $image, $entry_filename . '.pdf' );
 
-        // create 25 up output on 12 x 18
-        $this->create25Up( $image, $entry_filename );
+        // create 25 up output on 12 x 18 if flag is set
+        if ( $create25up ) {
+            $this->_create25Up( $image, $entry_filename );
+        }
 
         /** CREATE PNG FILE FOR PREVIEW */
         // Switch format to PNG
@@ -361,7 +369,7 @@ class Wp_Print_Preview_Helper
      * @param $image - Image Magick object (Business Card)
      * @param $filename - name of file to be saved as
      */
-    public function create25Up( $image, $filename )
+    private function _create25Up( $image, $filename )
     {
         // new filename for 25-up PDF
         $new_filename = $filename . '_25_up.pdf';

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -381,6 +381,13 @@ class Wp_Print_Preview_Helper
         // Create raw 17.5" x 10" 25 up (before adding padding to the edges for 18" x 12" centering)
         $montage = $stack->montageImage( new ImagickDraw(), '5x5', '2100x1200', 0, 0);
 
+        // create padding to center 25-up on 18" x 12" (Note: 300px = 1 in.)
+        $horizontalPadding = 300;           // 0.5 in.
+        $verticalPadding = 1200;            // 2 in.
+        $offsetX = $horizontalPadding / 2;  // 0.25 in.
+        $offsetY = $verticalPadding / 2;    // 2 in.
+        $montage->extentImage( 10800, 7200, -$offsetX, -$offsetY );
+
         $this->_writeToUploads( $montage, $new_filename );
     }
 }

--- a/public/class-wp-print-preview-public.php
+++ b/public/class-wp-print-preview-public.php
@@ -129,7 +129,7 @@ class Wp_Print_Preview_Public
         if ( isset($_GET['entry_id']) ) {
 
             $entry = GFAPI::get_entry($_GET['entry_id']);
-            $image = (new Wp_Print_Preview_Helper())->business_card_proof($entry);
+            $image = (new Wp_Print_Preview_Helper())->business_card_proof( $entry, false );
 
             // STORE IN PREVIEW PAGE TO USE FOR REDIRECT LATER
             $_SESSION['entry_id'] = $_GET['entry_id'];

--- a/wp-print-preview.php
+++ b/wp-print-preview.php
@@ -9,14 +9,14 @@
  * that starts the plugin.
  *
  * @link              https://jamespham.io
- * @since             1.0.0
+ * @since             1.1.0
  * @package           Wp_Print_Preview
  *
  * @wordpress-plugin
  * Plugin Name:       WP Print Preview
- * Plugin URI:        http://wp-wordpress/wp-print-preview
+ * Plugin URI:        https://github.com/vta/wp-print-preview
  * Description:       A WordPress print preview plugin to preview and output PNG file of a business card.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            James Pham
  * Author URI:        https://jamespham.io
  * License:           GPL-2.0+


### PR DESCRIPTION
This PR adds a new 25-up PDF output of Business Cards.

- [x] Outputs a PDF file that should contain 25 business cards total. It should center **17.5 x 10** on a **12 x 18** .
  - [x] Ensure that the resolution is still 300 DPI
  - [x] There should be 0.25-inch padding for the sides and 1-inch padding top and bottom for the 12x18 output.
- [x] `business_card_proof()` method has an additional argument for 25-up flag. This flag is necessary to turn off 25-up output during business card preview.
- [x] There should be a new link in the item's metadata. 
  - Please review this portion in `includes/wc-back-end.php` in `wc-backend-enhancements` branch from **copy-center-2.0.**

**Note**
- _We may need to increase the memory limit for Image Magick since 25-up outputs a large file._