### PR TITLE
Temporary PDF Output Method Change

### DIFF
--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -238,17 +238,17 @@ class Wp_Print_Preview_Helper
         $target = $uploads_dir['basedir'] . '/business_cards/' . $entry_filename . '.pdf';
         $target = str_replace ( ' ', '_', $target );
 
-        error_log($source);
-        error_log($target);
-        error_log('magick convert ' . $source . ' ' . $target);
+        // output & exit code for command line
         $output = [];
         $res = 0;
-//        exec( 'which magick' . ' 2>&1', $output, $res );
-        exec( '/usr/local/bin/magick convert ' . $source . ' ' . $target . ' 2>&1', $output, $res );
-//        $res = exec( 'magick convert ' . $source . ' ' . $target . ' 2>&1' );
+        // define PATH
+        putenv('PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin');
+        // run magick command to run
+        exec( 'magick convert ' . $source . ' ' . $target . ' 2>&1', $output, $res );
 
-        error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
-        error_log( $res );
+        if ( $res > 0 ) {
+            error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
+        }
 
         // return the img filename to shortcode
         return $temp_file;

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -8,7 +8,7 @@ class Wp_Print_Preview_Helper
      * @return string
      * @throws ImagickException
      */
-    public function business_card_proof( $entry, $create25up )
+    public function business_card_proof( $entry, $create25up, $isPreview )
     {
         // Store entry_id in SESSION
         // i.e. /?add_to_cart=39 will have access to this entry_id upon "Add Order"
@@ -229,25 +229,29 @@ class Wp_Print_Preview_Helper
         // write latest file to entry for preview
         $image->writeImage( $assets_dir . $temp_file . '.png' );
 
-        /**
-         * temp workaround to replace the above. Used the command line to write PDF file
-         * from temp_file
-         */
-        $source = $assets_dir . $temp_file . '.png';
-        $uploads_dir = wp_upload_dir();
-        $target = $uploads_dir['basedir'] . '/business_cards/' . $entry_filename . '.pdf';
-        $target = str_replace ( ' ', '_', $target );
+        // only write PDF if it is not preview
+        if ( ! $isPreview )
+        {
+            /**
+             * temp workaround to replace the above. Used the command line to write PDF file
+             * from temp_file
+             */
+            $source = $assets_dir . $temp_file . '.png';
+            $uploads_dir = wp_upload_dir();
+            $target = $uploads_dir['basedir'] . '/business_cards/' . $entry_filename . '.pdf';
+            $target = str_replace( ' ', '_', $target );
 
-        // output & exit code for command line
-        $output = [];
-        $res = 0;
-        // define PATH
-        putenv('PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin');
-        // run magick command to run
-        exec( 'magick convert ' . $source . ' ' . $target . ' 2>&1', $output, $res );
+            // output & exit code for command line
+            $output = [];
+            $res = 0;
+            // define PATH
+            putenv( 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' );
+            // run magick command to run
+            exec( 'magick convert ' . $source . ' ' . $target . ' 2>&1', $output, $res );
 
-        if ( $res > 0 ) {
-            error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
+            if ( $res > 0 ) {
+                error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
+            }
         }
 
         // return the img filename to shortcode

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -212,7 +212,7 @@ class Wp_Print_Preview_Helper
         // $image->writeImage($assets_dir . $entry_filename . '.pdf');
 
         // write Image to /wp-content/uploads/business_cards
-        $this->_writeToUploads( $image, $entry_filename . '.pdf' );
+//        $this->_writeToUploads( $image, $entry_filename . '.pdf' );
 
         // create 25 up output on 12 x 18 if flag is set
         if ( $create25up ) {
@@ -228,6 +228,27 @@ class Wp_Print_Preview_Helper
 
         // write latest file to entry for preview
         $image->writeImage( $assets_dir . $temp_file . '.png' );
+
+        /**
+         * temp workaround to replace the above. Used the command line to write PDF file
+         * from temp_file
+         */
+        $source = $assets_dir . $temp_file . '.png';
+        $uploads_dir = wp_upload_dir();
+        $target = $uploads_dir['basedir'] . '/business_cards/' . $entry_filename . '.pdf';
+        $target = str_replace ( ' ', '_', $target );
+
+        error_log($source);
+        error_log($target);
+        error_log('magick convert ' . $source . ' ' . $target);
+        $output = [];
+        $res = 0;
+//        exec( 'which magick' . ' 2>&1', $output, $res );
+        exec( '/usr/local/bin/magick convert ' . $source . ' ' . $target . ' 2>&1', $output, $res );
+//        $res = exec( 'magick convert ' . $source . ' ' . $target . ' 2>&1' );
+
+        error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
+        error_log( $res );
 
         // return the img filename to shortcode
         return $temp_file;

--- a/public/class-wp-print-preview-public.php
+++ b/public/class-wp-print-preview-public.php
@@ -129,7 +129,7 @@ class Wp_Print_Preview_Public
         if ( isset($_GET['entry_id']) ) {
 
             $entry = GFAPI::get_entry($_GET['entry_id']);
-            $image = (new Wp_Print_Preview_Helper())->business_card_proof( $entry, false );
+            $image = (new Wp_Print_Preview_Helper())->business_card_proof( $entry, false, true );
 
             // STORE IN PREVIEW PAGE TO USE FOR REDIRECT LATER
             $_SESSION['entry_id'] = $_GET['entry_id'];


### PR DESCRIPTION
|#487 https://projects.vta.org/projects/copy-center/work_packages/details/487

In the latest build of Copy Center 2.0, Image Magick no longer writes PDF files due to new security policies set by default configurations at the latest update. We have tried various methods to override this behavior, but no solutions have worked.

To allow our Copy Center team to continue printing business cards, we will implement a workaround with the standalone Image Magick.

**Requirements:**

_Within the Plugin:_
- [x] Update the code to use Image Magick CLI to convert the temporary PNG file to PDF. Use the CLI to write directly to the correct business cards uploads folder.

_Within CC 2.0 Repository:_
- [x] Update CC 2.0 Repository to install Image Magick correctly with all of its dependencies.