### PR TITLE
Temp 25 up

### DIFF
--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -397,30 +397,49 @@ class Wp_Print_Preview_Helper
     private function _create25Up( $image, $filename )
     {
         // new filename for 25-up PDF
-        $new_filename = $filename . '_25_up.pdf';
+//        $new_filename = $filename . '_25_up.pdf';
+//
+//        // create Stack of Images (i.e. 5x5)
+//        $stack = new Imagick();
+//
+//        // create 25 images in the stack at 300 DPI
+//        for ( $i = 0; $i < 25; $i++ )
+//        {
+//            $stack->addImage( $image );
+//            $stack->setImageColorspace( Imagick::COLORSPACE_SRGB );
+//            $stack->setImageUnits( Imagick::RESOLUTION_PIXELSPERINCH );
+//            $stack->setResolution( 600, 600 );
+//            $stack->setImageResolution( 300, 300 );
+//        }
+//        // Create raw 17.5" x 10" 25 up (before adding padding to the edges for 18" x 12" centering)
+//        $montage = $stack->montageImage( new ImagickDraw(), '5x5', '2100x1200', 0, 0);
+//
+//        // create padding to center 25-up on 18" x 12" (Note: 300px = 1 in.)
+//        $horizontalPadding = 300;           // 0.5 in.
+//        $verticalPadding = 1200;            // 2 in.
+//        $offsetX = $horizontalPadding / 2;  // 0.25 in.
+//        $offsetY = $verticalPadding / 2;    // 2 in.
+//        $montage->extentImage( 10800, 7200, -$offsetX, -$offsetY );
+//
+//        $this->_writeToUploads( $montage, $new_filename );
+        /**
+         * temp workaround to replace the above. Used the command line to write PDF file
+         * from temp_file
+         */
+        $uploads_dir = wp_upload_dir();
+        $source = $uploads_dir['basedir'] . '/business_cards/' . $filename . '.pdf';
+        $target = $uploads_dir['basedir'] . '/business_cards/' . $filename . '_25_up.pdf';
 
-        // create Stack of Images (i.e. 5x5)
-        $stack = new Imagick();
+        // output & exit code for command line
+        $output = [];
+        $res = 0;
+        // PATH should already be defined from single PDF output.
+        // run magick command to process 25-up image
+        exec( 'magick montage ' . $source . ' -duplicate 24 -tile 5x5 -geometry 2100x1200+0+0  '
+            . $target . ' 2>&1', $output, $res );
 
-        // create 25 images in the stack at 300 DPI
-        for ( $i = 0; $i < 25; $i++ )
-        {
-            $stack->addImage( $image );
-            $stack->setImageColorspace( Imagick::COLORSPACE_SRGB );
-            $stack->setImageUnits( Imagick::RESOLUTION_PIXELSPERINCH );
-            $stack->setResolution( 600, 600 );
-            $stack->setImageResolution( 300, 300 );
+        if ( $res > 0 ) {
+            error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
         }
-        // Create raw 17.5" x 10" 25 up (before adding padding to the edges for 18" x 12" centering)
-        $montage = $stack->montageImage( new ImagickDraw(), '5x5', '2100x1200', 0, 0);
-
-        // create padding to center 25-up on 18" x 12" (Note: 300px = 1 in.)
-        $horizontalPadding = 300;           // 0.5 in.
-        $verticalPadding = 1200;            // 2 in.
-        $offsetX = $horizontalPadding / 2;  // 0.25 in.
-        $offsetY = $verticalPadding / 2;    // 2 in.
-        $montage->extentImage( 10800, 7200, -$offsetX, -$offsetY );
-
-        $this->_writeToUploads( $montage, $new_filename );
     }
 }

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -242,7 +242,7 @@ class Wp_Print_Preview_Helper
             // define PATH
             putenv( 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' );
             // run magick command to run
-            exec( 'magick convert ' . $source . ' -resize 50% quality 300 ' . $target . ' 2>&1', $output, $res );
+            exec( 'magick convert ' . $source . ' -resize 50% ' . $target . ' 2>&1', $output, $res );
 
             if ( $res > 0 ) {
                 error_log( json_encode( $output, JSON_PRETTY_PRINT ) );
@@ -453,9 +453,9 @@ class Wp_Print_Preview_Helper
         // define PATH
         putenv( 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' );
         exec(
-            'magick montage ' . $base_png . ' -mode concatenate -duplicate 24 -tile 5x5 ' . $temp_25_png . ' && ' .
+            '(magick montage ' . $base_png . ' -mode concatenate -duplicate 24 -tile 5x5 ' . $temp_25_png . ' && ' .
             'magick convert ' . $temp_25_png . ' -density 600 -bordercolor white -border 150x600 ' . $final_25_pdf . ' && ' .
-            'rm ' . $temp_25_png,
+            'rm ' . $temp_25_png . ' 2>&1) > /dev/null 2>/dev/null &',
             $output,
             $res
         );

--- a/public/class-wp-print-preview-public.php
+++ b/public/class-wp-print-preview-public.php
@@ -1,6 +1,6 @@
 <?php
 
-include_once(plugin_dir_path(__DIR__) . '/includes/class-wp-print-preview-helper.php');
+include_once( plugin_dir_path( __DIR__ ) . '/includes/class-wp-print-preview-helper.php' );
 
 /**
  * The public-facing functionality of the plugin.
@@ -50,7 +50,7 @@ class Wp_Print_Preview_Public
      * @param string $version The version of this plugin.
      * @since    1.0.0
      */
-    public function __construct($plugin_name, $version)
+    public function __construct( $plugin_name, $version )
     {
 
         $this->plugin_name = $plugin_name;
@@ -78,7 +78,7 @@ class Wp_Print_Preview_Public
          * class.
          */
 
-        wp_enqueue_style($this->plugin_name, plugin_dir_url(__FILE__) . 'css/wp-print-preview-public.css', array(), $this->version, 'all');
+        wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/wp-print-preview-public.css', array(), $this->version, 'all' );
 
     }
 
@@ -102,7 +102,7 @@ class Wp_Print_Preview_Public
          * class.
          */
 
-        wp_enqueue_script($this->plugin_name, plugin_dir_url(__FILE__) . 'js/wp-print-preview-public.js', array('jquery'), $this->version, false);
+        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/wp-print-preview-public.js', array( 'jquery' ), $this->version, false );
 
     }
 
@@ -113,7 +113,7 @@ class Wp_Print_Preview_Public
      * @param $atts
      * @return string - HTML user front-end
      */
-    public function business_card_preview_shortcode($atts)
+    public function business_card_preview_shortcode( $atts )
     {
 
         $args = shortcode_atts(
@@ -126,10 +126,10 @@ class Wp_Print_Preview_Public
 
         // retrieve input values
         // $entry_id provided by query param
-        if ( isset($_GET['entry_id']) ) {
+        if ( isset( $_GET['entry_id'] ) ) {
 
-            $entry = GFAPI::get_entry($_GET['entry_id']);
-            $image = (new Wp_Print_Preview_Helper())->business_card_proof( $entry, false, true );
+            $entry = GFAPI::get_entry( $_GET['entry_id'] );
+            $image = ( new Wp_Print_Preview_Helper() )->business_card_proof( $entry, false, true );
 
             // STORE IN PREVIEW PAGE TO USE FOR REDIRECT LATER
             $_SESSION['entry_id'] = $_GET['entry_id'];
@@ -152,30 +152,33 @@ class Wp_Print_Preview_Public
         /**
          * @todo - Decide upon a better 'Confirmation/Cancellation' process, perhaps built-in GF methods or prior to this execution?
          */
-        if ( isset($_POST['back']) ) {
+        if ( isset( $_POST['back'] ) ) {
 
-            $entry = GFAPI::get_entry($_SESSION['entry_id']);
+            $entry = GFAPI::get_entry( $_SESSION['entry_id'] );
 
-            $due_date = $entry['13'];
-            $job_title = $entry['1'];
-            $firstname = $entry['2.3'];
-            $lastname = $entry['2.6'];
-            $department = $entry['9'];
-            $email = $entry['3'];
-            $address = $entry['5'];
-            $phone = $entry['6'];
-            $mobile = $entry['7'];
-            $fax = $entry['8'];
-            $quantity = $entry['10'];
+            $query_param_data = array(
+                'due_date'   => $entry['13'],
+                'job_title'  => $entry['1'],
+                'firstname'  => $entry['2.3'],
+                'lastname'   => $entry['2.6'],
+                'department' => $entry['9'],
+                'email'      => $entry['3'],
+                'address'    => $entry['5'],
+                'phone'      => $entry['6'],
+                'mobile'     => $entry['7'],
+                'fax'        => $entry['8'],
+                'quantity'   => $entry['10']
+            );
 
-            $redirect_url = '/business-card-printing/?due_date=' . $due_date . '&job_title=' . $job_title . '&firstname=' . $firstname .
-                '&lastname=' . $lastname . '&department=' . $department . '&email=' . $email . '&address=' . $address .
-                '&phone=' . $phone . '&mobile=' . $mobile . '&fax=' . $fax . '&quantity=' . $quantity;
+            // builds our query parameters and escapes any special URI encoded characters
+            $redirect_url = '/business-card-printing/?' . http_build_query( $query_param_data );
 
-            $redirect_url = str_replace(' ', '+', $redirect_url);
+            // Replace special query parameter characters
+            $redirect_url = str_replace( ' ', '+', $redirect_url );
+
 
             // Redirect user to the form
-            GFAPI::delete_entry($entry['id']);
+            GFAPI::delete_entry( $entry['id'] );
             return "
                 <script>
                     window.location.href='" . $redirect_url . "';


### PR DESCRIPTION
|#488 https://projects.vta.org/projects/copy-center/work_packages/488

Similar to the PDF output re-factor, revise the 25-up method to use Image Magick CLI execution instead of the PHP Imagick module. This way, we may _actually_ influence Image Magick configurations through **policy.xml**.

**Requirements:**
- [x] Use PHP's **exec()** to run a montage of the 25-up in a 12x18 output with the correct white space padding. Use the _create25up parameters to pass to the CLI options.
- [x] Test the output on dev. ~May require additional configuration to `policy.xml`.~ _Runs without any additional configuration._
- [x] Turn the image processing unit into an asynchronous task. Use the **&** operator to turn our magick command into a **background** job.

**Bugs:**
- [x] Fixed query parameter creation. It uses a dynamic array to insert query parameters while replacing any URI encoded characters.