### PR TITLE
Update Filename Output

### DIFF
--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -200,8 +200,12 @@ class Wp_Print_Preview_Helper
 
         }
 
-        // Form entry_id added to PDF preview
-        $entry_filename = 'bizcard_' . $first_name . '_' . $last_name . '_entry_' . $entry['id'];
+        // Account for special characters when generating the filename
+        $entry_filename = str_replace(
+            [' ', ',', '/', '"', '\'', '(', ')', '&', '#', '@', '$', '%', '|', '^', '\\'],
+            '_',
+            'bizcard_' . $first_name . '_' . $last_name . '_entry_' . $entry['id']
+        );
 
         $image->setFilename( $entry_filename );
 

--- a/includes/class-wp-print-preview-helper.php
+++ b/includes/class-wp-print-preview-helper.php
@@ -202,7 +202,7 @@ class Wp_Print_Preview_Helper
 
         // Account for special characters when generating the filename
         $entry_filename = str_replace(
-            [' ', ',', '/', '"', '\'', '(', ')', '&', '#', '@', '$', '%', '|', '^', '\\'],
+            [' ', ',', '?', '/', '"', '\'', '(', ')', '[', ']', '{', '}', '!', '&', '#', '@', '$', '%', '*', '|', '^', '\\'],
             '_',
             'bizcard_' . $first_name . '_' . $last_name . '_entry_' . $entry['id']
         );


### PR DESCRIPTION
|#490 https://projects.vta.org/projects/copy-center/work_packages/490

This PR addresses our current problem of business card filename generation. Before, we were only replacing white space within filenames with underscores. Now, we are replacing all special BASH characters with underscores.

Note:
1. Filenames are only dependent on first and last name fields.
2. This change should be replicated in the main CC 2.0 repo in `includes/wc-back-end.php`. Currently, it's being committed to the `daily-reminder-emails` branch.
3. Changes have already been implemented in production via SSH.
